### PR TITLE
use GH_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -5,8 +5,8 @@
     [
       "exec",
       {
-        "afterChangelog": "python3 scripts/parsever.py \"$ARG_0\"; export GITHUB_TOKEN=$(echo four)",
-        "afterPublish": "export GITHUB_TOKEN=$(echo four)"
+        "afterChangelog": "python3 scripts/parsever.py \"$ARG_0\"",
+        "afterPublish": "export GH_TOKEN=$WORKFLOW_TOKEN"
       }
     ]
   ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,6 @@ jobs:
 
       - name: "Run auto shipit"
         env: # token as an environment variable
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WORKFLOW_TOKEN: ${{ github.token }}
         run: "~/auto shipit -vv"


### PR DESCRIPTION
[you cannot write on vars with prefix of "GITHUB_"](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)